### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request introduces a change to the `.github/dependabot.yml` file to configure Dependabot to ignore major version updates for all dependencies.

Configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R16-R19): Added a new `ignore` section to specify that Dependabot should ignore major version updates for all dependencies.